### PR TITLE
Small change to camelcase class name for multi-word subclasses

### DIFF
--- a/lib/inherits-migration.rb
+++ b/lib/inherits-migration.rb
@@ -14,7 +14,7 @@ module InheritsMigration
     
     create_table_without_inherits(table_name, options) do |table_defintion|
       if options[:inherits]
-        association_type = Object.const_get(options[:inherits].to_s.capitalize)
+        association_type = Object.const_get(options[:inherits].to_s.camelcase)
         association_inst = association_type.send(:new)
         attr_column = association_inst.column_for_attribute(association_type.primary_key)
         


### PR DESCRIPTION
Subclasses (eg :inherits => :my_detail) were being capitalized instead of camelcased so rake db:migrate was looking for class My_detail instead of MyDetail.
