### PR TITLE
Fix bug for find(:all), change for Rails 3.1, and save/validation callback change

### DIFF
--- a/lib/class-table-inheritance.rb
+++ b/lib/class-table-inheritance.rb
@@ -58,7 +58,7 @@ class ActiveRecord::Base
   
     # bind the before save, this method call the save of association, and
     # get our generated ID an set to association_id field.
-    before_save :save_inherit
+    before_validation :set_inherit
   
   
     # Bind the validation of association.
@@ -125,10 +125,10 @@ class ActiveRecord::Base
     end
 
 
-    # Create a method do bind in before_save callback, this method
+    # Create a method do bind in before_validation callback, this method
     # only call the save of association class and set the id in the
     # generalized class.
-    define_method("save_inherit") do |*args|
+    define_method("set_inherit") do |*args|
       association = send(association_id)
       if association.attribute_names.include?("subtype")
         association.subtype = self.class.to_s

--- a/lib/class-table-inheritance.rb
+++ b/lib/class-table-inheritance.rb
@@ -38,7 +38,7 @@ class ActiveRecord::Base
   def self.inherits_from(association_id, inherit_methods = false)
     
     # add an association, and set the foreign key.
-    has_one association_id, :foreign_key => :id, :dependent => :destroy
+    belongs_to association_id, :dependent => :destroy
 
 
     # set the primary key, it' need because the generalized table doesn't have
@@ -81,7 +81,7 @@ class ActiveRecord::Base
   
     # get the class of association by reflection, this is needed because
     # i need to get the methods and attributes to make a proxy methods.
-    reflection = create_reflection(:has_one, association_id, {}, self)
+    reflection = create_reflection(:belongs_to, association_id, {}, self)
     association_class = reflection.class_name.constantize
     # Get the colluns of association class.
     inherited_columns = association_class.column_names

--- a/lib/class-table-inheritance.rb
+++ b/lib/class-table-inheritance.rb
@@ -13,17 +13,17 @@ class ActiveRecord::Base
         begin
           if super_classes.kind_of? Array
             super_classes.map do |item|
-              if !item.subtype.nil? && !item.subtype.blank?
+              if !item.subtype.blank?
                 inherits_type = item.subtype.to_s.classify.constantize
-                inherits_type.send(:find, item.id)
+                inherits_type.find(item.id)
               else
                 super_classes
               end
             end
           else
-            if !super_classes.subtype.nil? && !super_classes.subtype.blank?
+            if !super_classes.subtype.blank?
               inherits_type = super_classes.subtype.to_s.classify.constantize
-              inherits_type.send(:find, *args)
+              inherits_type.find(super_classes.id)
             else
               super_classes
             end

--- a/lib/class-table-inheritance.rb
+++ b/lib/class-table-inheritance.rb
@@ -35,7 +35,7 @@ class ActiveRecord::Base
     end  
   end
 
-  def self.inherits_from(association_id)
+  def self.inherits_from(association_id, inherit_methods = false)
     
     # add an association, and set the foreign key.
     has_one association_id, :foreign_key => :id, :dependent => :destroy
@@ -136,6 +136,19 @@ class ActiveRecord::Base
       association.save
       self["#{association_id}_id"] = association.id
       true
+    end
+
+    # delegate all missing method calls to the parent association if
+    # inherit_methods parameter is true
+    if inherit_methods
+      define_method("method_mising") do |name, *args|
+        association = self.public_send(association_id)
+        if association.respond_to? name
+          association.send(name, *args)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/class-table-inheritance.rb
+++ b/lib/class-table-inheritance.rb
@@ -141,12 +141,12 @@ class ActiveRecord::Base
     # delegate all missing method calls to the parent association if
     # inherit_methods parameter is true
     if inherit_methods
-      define_method("method_mising") do |name, *args|
+      define_method("method_missing") do |name, *args|
         association = self.public_send(association_id)
         if association.respond_to? name
           association.send(name, *args)
         else
-          super
+          super name, *args
         end
       end
     end

--- a/lib/class-table-inheritance.rb
+++ b/lib/class-table-inheritance.rb
@@ -14,7 +14,7 @@ class ActiveRecord::Base
           if super_classes.kind_of? Array
             super_classes.map do |item|
               if !item.subtype.nil? && !item.subtype.blank?
-                inherits_type = super_classes.subtype.to_s.classify.constantize
+                inherits_type = item.subtype.to_s.classify.constantize
                 inherits_type.send(:find, item.id)
               else
                 super_classes

--- a/lib/inherits-migration.rb
+++ b/lib/inherits-migration.rb
@@ -7,24 +7,15 @@ module InheritsMigration
       alias_method_chain :create_table , :inherits
     end
   end
-  
+
   # Generate the association field.
   def create_table_with_inherits(table_name, options = {}, &block)
-    options[:id] ||= false if options[:inherits]
-    
+    options[:primary_key] = "#{options[:inherits]}_id" if options[:inherits]
+
     create_table_without_inherits(table_name, options) do |table_defintion|
-      if options[:inherits]
-        association_type = options[:inherits].to_s.classify.constantize 
-        association_inst = association_type.send(:new)
-        attr_column = association_inst.column_for_attribute(association_type.primary_key)
-        
-        field_option = {:primary_key => true, :null => false}
-        field_option[:limit] = attr_column.limit if attr_column.limit                
-        table_defintion.column "#{options[:inherits]}_id", attr_column.type, field_option
-      end
-      yield table_defintion  
-    end 
-  end  
+      yield table_defintion   
+    end  
+  end
 end
 
 ActiveRecord::Base


### PR DESCRIPTION
This pull request fixes/changes 3 things

* With the pull request that was just accepted from @mremolt's branch, it looks like the wrong variable for calls to find(:all) are being referenced on line 17 of `lib/class_table_inheritance.rb`.  Instead of using `item`, (which would correctly reference the current item in the loop), `super_classes` is being used (which incorrectly references the array, causing an error).

    The effect of the bug is that when performing a top-down find(:all) on the parent model, it will not be able to retrieve the child attributes.

* Converted `has_one` association to `belongs_to` for inheriting class to properly work in Rails 3.1.  (I believe this should still properly work in Rails 3.0 and below, though I have not tested it.)

* Changed `before_save` to `before_validation` when setting the `subtype` value so that the superclass model can include a subtype validation rule to test presence (and we can require the column to not allow nulls).