### PR TITLE
Fixed Deprication Warning for set_primary_key

### DIFF
--- a/lib/class-table-inheritance/class-table-inheritance.rb
+++ b/lib/class-table-inheritance/class-table-inheritance.rb
@@ -48,7 +48,7 @@ class ActiveRecord::Base
 
     # set the primary key, it' need because the generalized table doesn't have
     # a field ID.
-    set_primary_key "#{association_id}_id"
+    self.primary_key = "#{association_id}_id"
 
 
     # Autobuild method to make a instance of association


### PR DESCRIPTION
- Fixed 
  - DEPRECATION WARNING: Calling set_primary_key is deprecated. Please use `self.primary_key = 'the_name'` instead
