### PR TITLE
Revert the association to allow foreign keys

### DIFF
--- a/lib/class-table-inheritance/class-table-inheritance.rb
+++ b/lib/class-table-inheritance/class-table-inheritance.rb
@@ -42,8 +42,8 @@ class ActiveRecord::Base
       class_name = association_id.to_s.classify
     end
     
-    # add an association, and set the foreign key.
-    has_one association_id, :class_name => class_name, :foreign_key => :id, :dependent => :destroy
+    # add an association
+    belongs_to association_id, :class_name => class_name, :dependent => :destroy
 
 
     # set the primary key, it' need because the generalized table doesn't have


### PR DESCRIPTION
By reverting the association from has_one to belongs_to the order of deletion is reverted so that the subclass is deleted before the superclass.  Since foreign keys point from the subclass to the super class, this avoids the foreign key violation.
