### PR TITLE
Update the gem to the current state of the world :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
+/Gemfile.lock
 test/cti_plugin.sqlite3

--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,15 @@
 Change log
 ----------
 
-* Now you can inherits from and to modules like inherits_from 'Module::Model', see the the name of field 
-must be module_model_id:integer thanks for Marc Remolt (https://github.com/mremolt).
+### 1.3.1
+
+* Removed 'set_primary_key' deprecation warning
+* Make the gem depencies explicit and require ActiveRecord 4.x or 5.0
+
+
+### 1.3.0
+* Now you can inherits from and to modules like inherits_from 'Module::Model', see the the name of
+  field must be module_model_id:integer thanks for Marc Remolt (https://github.com/mremolt).
 * Unit test
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'bundler'
+require 'bundler/setup'
 require 'rake/testtask'
 Bundler::GemHelper.install_tasks
 

--- a/class-table-inheritance.gemspec
+++ b/class-table-inheritance.gemspec
@@ -18,4 +18,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_runtime_dependency 'activerecord', '>=4', '<5.1'
+
+  s.add_development_dependency 'minitest-reporters','~>1.1'
+  s.add_development_dependency 'rake', '>=11'
+  s.add_development_dependency 'sqlite3', '~>1.3'
 end

--- a/test/class_table_inheritance_test.rb
+++ b/test/class_table_inheritance_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ClassTableInheritanceTest < Test::Unit::TestCase
+class ClassTableInheritanceTest < Minitest::Test
   
   def test_create
     name = 'Bike'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
+require 'minitest/reporters'
 require 'active_record'
 require 'class-table-inheritance'
 require 'yaml'
+
+Minitest::Reporters.use!
 
 database = YAML::load(IO.read(File.dirname(__FILE__) + '/database.yml'))
 ActiveRecord::Base.establish_connection(database['sqlite3'])


### PR DESCRIPTION
Test::Unit => Minitest (that is what ActiveRecord already depends on)
Make the implicit gem dependencies explicit
Add a nice minitest-reporters for commandline and IDE test reporting